### PR TITLE
safe level 4 is obsolete on ruby 2.1.x

### DIFF
--- a/lib/twowaysql/node.rb
+++ b/lib/twowaysql/node.rb
@@ -73,7 +73,7 @@ module TwoWaySQL
 
     private
     def safe_eval(ctx, exp)
-      within_safe_level(4) { eval(exp) }
+      within_safe_level(3) { eval(exp) }
     end
 
     def within_safe_level(level)


### PR DESCRIPTION
I'd like to use twowaysql on ruby 2.1.x.
https://bugs.ruby-lang.org/issues/8468
